### PR TITLE
feat(node-hl7-server): expose underlying socket on InboundRequest

### DIFF
--- a/__tests__/server/hl7.server.test.ts
+++ b/__tests__/server/hl7.server.test.ts
@@ -1,3 +1,4 @@
+import { Socket } from "net";
 import { HL7ListenerError, InboundRequest, Server } from "node-hl7-server/src";
 import { describe, expect, test } from "vitest";
 
@@ -5,7 +6,10 @@ describe("node hl7 server", () => {
   describe("sanity tests - modules", () => {
     test("InboundRequest - message undefined", async () => {
       // @ts-expect-error
-      const empty = new InboundRequest(undefined, { type: "file" });
+      const empty = new InboundRequest(undefined, {
+        type: "file",
+        socket: undefined,
+      });
       try {
         empty.getMessage();
       } catch (e) {
@@ -17,8 +21,15 @@ describe("node hl7 server", () => {
 
     test("InboundRequest - type check", async () => {
       // @ts-expect-error
-      const req = new InboundRequest("", { type: "file" });
+      const req = new InboundRequest("", { type: "file", socket: undefined });
       expect(req.getType()).toBe("file");
+    });
+
+    test("InboundRequest - socket accessor returns the socket", async () => {
+      const socket = new Socket();
+      // @ts-expect-error
+      const req = new InboundRequest("", { type: "file", socket });
+      expect(req.getSocket()).toBe(socket);
     });
   });
 
@@ -215,7 +226,10 @@ describe("node hl7 server", () => {
     test("error - getMessage() - no message passed to inbound request", async () => {
       try {
         // @ts-expect-error no message.
-        const inboundReq = new InboundRequest("", { type: "message" });
+        const inboundReq = new InboundRequest("", {
+          type: "message",
+          socket: undefined,
+        });
         // this should cause an error
         inboundReq.getMessage();
       } catch (err: any) {

--- a/packages/node-hl7-server/src/server/inbound.ts
+++ b/packages/node-hl7-server/src/server/inbound.ts
@@ -96,7 +96,7 @@ export class Inbound extends EventEmitter implements IInbound {
       const parsed = new Message({ text: message.toString() });
       ++this.stats.totalMessage;
 
-      const req = new InboundRequest(parsed, { type });
+      const req = new InboundRequest(parsed, { type, socket });
       const res = new this._sendResponseClass(
         socket,
         parsed,
@@ -225,7 +225,10 @@ export class Inbound extends EventEmitter implements IInbound {
             const parsed = new Message({ text: completedMessageCopy });
             ++this.stats.totalMessage;
 
-            const req = new InboundRequest(parsed, { type: "message" });
+            const req = new InboundRequest(parsed, {
+              type: "message",
+              socket,
+            });
             const res = new this._sendResponseClass(
               socket,
               parsed,

--- a/packages/node-hl7-server/src/server/modules/inboundRequest.ts
+++ b/packages/node-hl7-server/src/server/modules/inboundRequest.ts
@@ -1,4 +1,5 @@
 import { HL7ListenerError } from "@/utils/exception";
+import type { Socket } from "net";
 import { Message } from "node-hl7-client";
 
 /**
@@ -7,6 +8,7 @@ import { Message } from "node-hl7-client";
  */
 export interface InboundRequestProps {
   type: string;
+  socket: Socket;
 }
 
 /**
@@ -18,6 +20,8 @@ export class InboundRequest {
   private readonly _message?: Message;
   /** @internal */
   private readonly _fromType: string;
+  /** @internal */
+  private readonly _socket: Socket;
 
   /**
    * @since 1.0.0
@@ -26,6 +30,7 @@ export class InboundRequest {
    */
   constructor(message: Message, props: InboundRequestProps) {
     this._fromType = props.type;
+    this._socket = props.socket;
     this._message = message;
   }
 
@@ -42,5 +47,17 @@ export class InboundRequest {
 
   getType(): string {
     return this._fromType;
+  }
+
+  /**
+   * Get the underlying TCP/TLS socket the message arrived on.
+   * Useful for downstream consumers that need access to peer/local
+   * address pairs (e.g. for conntrack lookups when the listener sits
+   * behind DNAT or a load balancer with floating-IP rules) and
+   * therefore cannot rely on a single `port → client` mapping.
+   * @since 4.0.0
+   */
+  getSocket(): Socket {
+    return this._socket;
   }
 }


### PR DESCRIPTION
## Summary

Add a `socket` field to `InboundRequestProps` and a corresponding `InboundRequest.getSocket()` accessor so handlers can reach the underlying TCP/TLS socket the message arrived on.

The `Inbound` listener already holds the live socket while it constructs the request and response objects; this PR just forwards it through to the handler. Useful when the handler needs peer/local address pairs to make routing decisions that depend on connection-level metadata rather than message content.

## What changes

- `InboundRequestProps` gains `socket: Socket`.
- `InboundRequest` stores it and exposes `getSocket(): Socket`.
- The two `new InboundRequest(...)` call sites in `Inbound` (in `_handleMessages` and the single-message path of `_onTcpClientConnected`) now pass the active socket.

The change is additive: existing consumers that ignore the new method are unaffected. Callers constructing `InboundRequest` directly (only seen in tests) must now include `socket` in the props.

## Test plan

- Existing `InboundRequest` tests updated to pass the new prop.
- New `InboundRequest - socket accessor returns the socket` test verifies the accessor wires through correctly.