### PR TITLE
feat(client, server): require explicit HL7 version per client and listener

### DIFF
--- a/__tests__/client/hl7.client.test.ts
+++ b/__tests__/client/hl7.client.test.ts
@@ -29,17 +29,17 @@ describe("node hl7 client", () => {
   describe("Client class", () => {
     describe("valid", () => {
       test("valid - properties exist", async () => {
-        const client = new Client({ host: "hl7.server.local" });
+        const client = new Client({ host: "hl7.server.local", version: "2.7" });
         expect(client).toHaveProperty("createConnection");
       });
 
       test("getHost returns the configured host", async () => {
-        const client = new Client({ host: "hl7.server.local" });
+        const client = new Client({ host: "hl7.server.local", version: "2.7" });
         expect(client.getHost()).toEqual("hl7.server.local");
       });
 
       test("port is set on outbound connection", async () => {
-        const client = new Client({ host: "hl7.server.local" });
+        const client = new Client({ host: "hl7.server.local", version: "2.7" });
         const outbound = client.createConnection(
           { autoConnect: false, port: 12_345 },
           async () => {},
@@ -54,7 +54,7 @@ describe("node hl7 client", () => {
         expect.assertions(1);
         try {
           // @ts-expect-error hostname has to be string
-          new Client({ host: 351_123 });
+          new Client({ host: 351_123, version: "2.7" });
         } catch (error: any) {
           expect(error.message).toBe("host is not valid string.");
         }
@@ -62,14 +62,20 @@ describe("node hl7 client", () => {
 
       test("accepts ipv4 and ipv6 both true (dual-stack)", async () => {
         expect(
-          () => new Client({ host: "5.8.6.1", ipv4: true, ipv6: true }),
+          () =>
+            new Client({
+              host: "5.8.6.1",
+              ipv4: true,
+              ipv6: true,
+              version: "2.7",
+            }),
         ).not.toThrow();
       });
 
       test("rejects malformed IPv4 host when ipv4 is exclusive", async () => {
         expect.assertions(1);
         try {
-          new Client({ host: "123.34.52.455", ipv4: true });
+          new Client({ host: "123.34.52.455", ipv4: true, version: "2.7" });
         } catch (error: any) {
           expect(error.message).toBe("host is not a valid IPv4 address.");
         }
@@ -77,7 +83,8 @@ describe("node hl7 client", () => {
 
       test("accepts valid IPv4 host when ipv4 is exclusive", async () => {
         expect(
-          () => new Client({ host: "123.34.52.45", ipv4: true }),
+          () =>
+            new Client({ host: "123.34.52.45", ipv4: true, version: "2.7" }),
         ).not.toThrow();
       });
 
@@ -87,6 +94,7 @@ describe("node hl7 client", () => {
           new Client({
             host: "2001:0db8:85a3:0000:zz00:8a2e:0370:7334",
             ipv6: true,
+            version: "2.7",
           });
         } catch (error: any) {
           expect(error.message).toBe("host is not a valid IPv6 address.");
@@ -99,6 +107,7 @@ describe("node hl7 client", () => {
             new Client({
               host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
               ipv6: true,
+              version: "2.7",
             }),
         ).not.toThrow();
       });
@@ -106,7 +115,12 @@ describe("node hl7 client", () => {
       test("rejects ipv4 and ipv6 both false", async () => {
         expect.assertions(1);
         try {
-          new Client({ host: "192.0.2.1", ipv4: false, ipv6: false });
+          new Client({
+            host: "192.0.2.1",
+            ipv4: false,
+            ipv6: false,
+            version: "2.7",
+          });
         } catch (error: any) {
           expect(error.message).toBe(
             "ipv4 and ipv6 cannot both be disabled — at least one address family must be enabled.",
@@ -120,7 +134,7 @@ describe("node hl7 client", () => {
     let client: Client;
 
     beforeEach(() => {
-      client = new Client({ host: "localhost" });
+      client = new Client({ host: "localhost", version: "2.7" });
     });
 
     test("rejects createConnection with no port", async () => {

--- a/__tests__/client/hl7.dualstack.test.ts
+++ b/__tests__/client/hl7.dualstack.test.ts
@@ -94,21 +94,25 @@ describe("dual-stack & IP family handling", () => {
 
   describe("Client option normalization", () => {
     test("IPv4-only is the default", () => {
-      const client = new Client({ host: "hl7.example.com" });
+      const client = new Client({ host: "hl7.example.com", version: "2.7" });
       expect(client._opt.ipv4).toBe(true);
       expect(client._opt.ipv6).toBe(false);
       expect(client._opt.family).toBe(4);
     });
 
     test("explicit ipv4: true alone forces IPv4-only family", () => {
-      const client = new Client({ host: "192.0.2.1", ipv4: true });
+      const client = new Client({
+        host: "192.0.2.1",
+        ipv4: true,
+        version: "2.7",
+      });
       expect(client._opt.ipv4).toBe(true);
       expect(client._opt.ipv6).toBe(false);
       expect(client._opt.family).toBe(4);
     });
 
     test("explicit ipv6: true alone forces IPv6-only family", () => {
-      const client = new Client({ host: "::1", ipv6: true });
+      const client = new Client({ host: "::1", ipv6: true, version: "2.7" });
       expect(client._opt.ipv4).toBe(false);
       expect(client._opt.ipv6).toBe(true);
       expect(client._opt.family).toBe(6);
@@ -119,6 +123,7 @@ describe("dual-stack & IP family handling", () => {
         host: "hl7.example.com",
         ipv4: true,
         ipv6: true,
+        version: "2.7",
       });
       expect(client._opt.ipv4).toBe(true);
       expect(client._opt.ipv6).toBe(true);
@@ -128,12 +133,22 @@ describe("dual-stack & IP family handling", () => {
     });
 
     test("dual-stack with IPv6 literal pins family to 6", () => {
-      const client = new Client({ host: "::1", ipv4: true, ipv6: true });
+      const client = new Client({
+        host: "::1",
+        ipv4: true,
+        ipv6: true,
+        version: "2.7",
+      });
       expect(client._opt.family).toBe(6);
     });
 
     test("dual-stack with IPv4 literal pins family to 4", () => {
-      const client = new Client({ host: "127.0.0.1", ipv4: true, ipv6: true });
+      const client = new Client({
+        host: "127.0.0.1",
+        ipv4: true,
+        ipv6: true,
+        version: "2.7",
+      });
       expect(client._opt.family).toBe(4);
     });
 
@@ -143,6 +158,7 @@ describe("dual-stack & IP family handling", () => {
         host: "hl7.example.com",
         ipv4: true,
         ipv6: true,
+        version: "2.7",
       });
       expect(client._opt.autoSelectFamily).toBe(false);
     });
@@ -150,7 +166,7 @@ describe("dual-stack & IP family handling", () => {
     test("rejects an IPv6 literal when ipv4 is exclusive", () => {
       expect.assertions(1);
       try {
-        new Client({ host: "::1", ipv4: true });
+        new Client({ host: "::1", ipv4: true, version: "2.7" });
       } catch (error: any) {
         expect(error.message).toBe("host is not a valid IPv4 address.");
       }
@@ -159,7 +175,7 @@ describe("dual-stack & IP family handling", () => {
     test("rejects an IPv4 literal when ipv6 is exclusive", () => {
       expect.assertions(1);
       try {
-        new Client({ host: "127.0.0.1", ipv6: true });
+        new Client({ host: "127.0.0.1", ipv6: true, version: "2.7" });
       } catch (error: any) {
         expect(error.message).toBe("host is not a valid IPv6 address.");
       }
@@ -171,6 +187,7 @@ describe("dual-stack & IP family handling", () => {
         new Client({
           autoSelectFamilyAttemptTimeout: 5,
           host: "192.0.2.1",
+          version: "2.7",
         });
       } catch (error: any) {
         expect(error.message).toMatch(
@@ -270,13 +287,20 @@ describe("dual-stack & IP family handling", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "127.0.0.1", ipv4: true });
-      const listener = server.createInbound({ port }, async (_request, res) => {
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (_request, res) => {
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "127.0.0.1", ipv4: true });
+      const client = new Client({
+        host: "127.0.0.1",
+        ipv4: true,
+        version: "2.7",
+      });
       const outbound = client.createConnection(
         { port },
         async (res: InboundResponse) => {
@@ -299,13 +323,16 @@ describe("dual-stack & IP family handling", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "::1", ipv6: true });
-      const listener = server.createInbound({ port }, async (_request, res) => {
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (_request, res) => {
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "::1", ipv6: true });
+      const client = new Client({ host: "::1", ipv6: true, version: "2.7" });
       const outbound = client.createConnection(
         { port },
         async (res: InboundResponse) => {
@@ -328,15 +355,22 @@ describe("dual-stack & IP family handling", () => {
 
       // Opt into dual-stack: bindAddress "::", ipv6Only=false
       const server = new Server({ ipv4: true, ipv6: true });
-      const listener = server.createInbound({ port }, async (_request, res) => {
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (_request, res) => {
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
       // IPv4 client
       const v4Done = createDeferred<void>();
-      const clientV4 = new Client({ host: "127.0.0.1", ipv4: true });
+      const clientV4 = new Client({
+        host: "127.0.0.1",
+        ipv4: true,
+        version: "2.7",
+      });
       const v4Out = clientV4.createConnection(
         { port },
         async (res: InboundResponse) => {
@@ -352,7 +386,7 @@ describe("dual-stack & IP family handling", () => {
 
       // IPv6 client
       const v6Done = createDeferred<void>();
-      const clientV6 = new Client({ host: "::1", ipv6: true });
+      const clientV6 = new Client({ host: "::1", ipv6: true, version: "2.7" });
       const v6Out = clientV6.createConnection(
         { port },
         async (res: InboundResponse) => {
@@ -378,9 +412,12 @@ describe("dual-stack & IP family handling", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "127.0.0.1", ipv4: true });
-      const listener = server.createInbound({ port }, async (_request, res) => {
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (_request, res) => {
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
@@ -389,6 +426,7 @@ describe("dual-stack & IP family handling", () => {
         host: "localhost",
         ipv4: true,
         ipv6: true,
+        version: "2.7",
       });
       const outbound = client.createConnection(
         { maxConnectionAttempts: 2, port },

--- a/__tests__/client/hl7.end2end.test.ts
+++ b/__tests__/client/hl7.end2end.test.ts
@@ -55,15 +55,18 @@ describe("node hl7 end to end - client", () => {
       const dfdConnectionChecks = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -119,16 +122,19 @@ describe("node hl7 end to end - client", () => {
       let totalSent = 0;
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        totalSent++;
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          totalSent++;
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port, waitAck: false },
         async () => {
@@ -159,7 +165,7 @@ describe("node hl7 end to end - client", () => {
       const mockPort = 9999;
 
       test("... queues messages (autoConnect: false)", async () => {
-        const client = new Client({ host: "0.0.0.0" });
+        const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
         const outbound = client.createConnection(
           { autoConnect: false, port: mockPort },
@@ -219,7 +225,7 @@ describe("node hl7 end to end - client", () => {
           }
         };
 
-        const client = new Client({ host: "0.0.0.0" });
+        const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
         const outbound = client.createConnection(
           {
@@ -240,7 +246,7 @@ describe("node hl7 end to end - client", () => {
 
       // note: this test fails on github. The local redis server is flaky. It does work locally.
       test.skip("... queues messages 10,001 still is 10000 (autoConnect: false)", async () => {
-        const client = new Client({ host: "0.0.0.0" });
+        const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
         const outbound = client.createConnection(
           { autoConnect: false, port: mockPort },
@@ -267,7 +273,11 @@ describe("node hl7 end to end - client", () => {
       // Find a free port — no server will be started on it, so connection must fail.
       const port = await portfinder.getPortPromise();
 
-      const client = new Client({ connectionTimeout: 1000, host: "0.0.0.0" });
+      const client = new Client({
+        connectionTimeout: 1000,
+        host: "0.0.0.0",
+        version: "2.7",
+      });
       const outbound = client.createConnection({ port }, async () => {});
 
       // ECONNREFUSED fires almost immediately (before the 1s timeout), so
@@ -286,6 +296,7 @@ describe("node hl7 end to end - client", () => {
         connectionTimeout: 1000,
         host: "0.0.0.0",
         tls: { rejectUnauthorized: false },
+        version: "2.7",
       });
       const outbound = client.createConnection({ port }, async () => {});
 
@@ -304,15 +315,18 @@ describe("node hl7 end to end - client", () => {
         const dfd = createDeferred<void>();
 
         const server = new Server({ bindAddress: "0.0.0.0" });
-        const inbound = server.createInbound({ port }, async (request, res) => {
-          const messageRequest = request.getMessage();
-          expect(messageRequest.get("MSH.12").toString()).toBe("2.1");
-          await res.sendResponse("AA");
-        });
+        const inbound = server.createInbound(
+          { port, version: "2.1" },
+          async (request, res) => {
+            const messageRequest = request.getMessage();
+            expect(messageRequest.get("MSH.12").toString()).toBe("2.1");
+            await res.sendResponse("AA");
+          },
+        );
 
         await expectEvent(inbound, "listen");
 
-        const client = new Client({ host: "0.0.0.0" });
+        const client = new Client({ host: "0.0.0.0", version: "2.1" });
         // Resolve only after both ACKs arrive so the totalAck() assertion below
         // is not racing the second ACK.
         let acksReceived = 0;
@@ -372,17 +386,21 @@ describe("node hl7 end to end - client", () => {
             rejectUnauthorized: false,
           },
         });
-        const inbound = server.createInbound({ port }, async (request, res) => {
-          const messageRequest = request.getMessage();
-          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-          await res.sendResponse("AA");
-        });
+        const inbound = server.createInbound(
+          { port, version: "2.7" },
+          async (request, res) => {
+            const messageRequest = request.getMessage();
+            expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+            await res.sendResponse("AA");
+          },
+        );
 
         await expectEvent(inbound, "listen");
 
         const client = new Client({
           host: "0.0.0.0",
           tls: { rejectUnauthorized: false },
+          version: "2.7",
         });
         const outbound = client.createConnection(
           { port },

--- a/__tests__/client/hl7.version.test.ts
+++ b/__tests__/client/hl7.version.test.ts
@@ -1,0 +1,172 @@
+/*
+MIT License
+
+Copyright (c) 2026 Shane
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+import Client, {
+  Batch,
+  FileBatch,
+  isKnownVersion,
+  KNOWN_VERSIONS,
+  Message,
+} from "node-hl7-client/src";
+import { describe, expect, test, vi } from "vitest";
+
+import { expectHL7FatalError } from "./__utils__/expectHL7FatalError";
+
+/** Build a valid HL7 message at a specific version. */
+function makeMessage(
+  version: string,
+  controlId: string = "CONTROL_ID",
+): Message {
+  return new Message({
+    text: String.raw`MSH|^~\&|||||20240101000000||ADT^A01|${controlId}|D|${version}`,
+  });
+}
+
+describe("client HL7 version pin", () => {
+  describe("runtime known-version exports", () => {
+    test("KNOWN_VERSIONS lists every supported version", () => {
+      expect(KNOWN_VERSIONS).toEqual([
+        "2.1",
+        "2.2",
+        "2.3",
+        "2.3.1",
+        "2.4",
+        "2.5",
+        "2.5.1",
+        "2.6",
+        "2.7",
+        "2.7.1",
+        "2.8",
+      ]);
+    });
+
+    test("isKnownVersion accepts known versions and rejects others", () => {
+      expect(isKnownVersion("2.7")).toBe(true);
+      expect(isKnownVersion("2.5.1")).toBe(true);
+      expect(isKnownVersion("2.9")).toBe(false);
+      expect(isKnownVersion("")).toBe(false);
+      expect(isKnownVersion()).toBe(false);
+      expect(isKnownVersion(27)).toBe(false);
+    });
+  });
+
+  describe("construction", () => {
+    test("throws when version is missing", () => {
+      expect.assertions(2);
+      try {
+        // @ts-expect-error version is required
+        new Client({ host: "localhost" });
+      } catch (error) {
+        expectHL7FatalError(error, "version is not defined.");
+      }
+    });
+
+    test("throws when version is not a known HL7 version", () => {
+      expect.assertions(2);
+      try {
+        // @ts-expect-error version must be a known HL7 version
+        new Client({ host: "localhost", version: "2.9" });
+      } catch (error) {
+        expectHL7FatalError(error, 'version "2.9" is not a known HL7 version.');
+      }
+    });
+
+    test("accepts a known version and exposes it on the options", () => {
+      const client = new Client({ host: "localhost", version: "2.5" });
+      expect(client._opt.version).toBe("2.5");
+    });
+  });
+
+  describe("sendMessage version enforcement", () => {
+    test("rejects a single message whose MSH.12 differs from the client version", async () => {
+      const client = new Client({ host: "localhost", version: "2.7" });
+      const outbound = client.createConnection(
+        { autoConnect: false, port: 9999 },
+        async () => {},
+      );
+      vi.spyOn(outbound as any, "_connect").mockReturnValue();
+
+      await expect(outbound.sendMessage(makeMessage("2.5"))).rejects.toThrow(
+        'message version "2.5" does not match the connection version "2.7".',
+      );
+
+      client.closeAll();
+    });
+
+    test("accepts a single message that matches the client version", async () => {
+      const client = new Client({ host: "localhost", version: "2.7" });
+      const outbound = client.createConnection(
+        { autoConnect: false, port: 9999 },
+        async () => {},
+      );
+      vi.spyOn(outbound as any, "_connect").mockReturnValue();
+
+      await expect(
+        outbound.sendMessage(makeMessage("2.7")),
+      ).resolves.toBeUndefined();
+
+      client.closeAll();
+    });
+
+    test("rejects a batch when any contained message mismatches the version", async () => {
+      const client = new Client({ host: "localhost", version: "2.7" });
+      const outbound = client.createConnection(
+        { autoConnect: false, port: 9999 },
+        async () => {},
+      );
+      vi.spyOn(outbound as any, "_connect").mockReturnValue();
+
+      const batch = new Batch();
+      batch.start();
+      batch.add(makeMessage("2.7", "CTRL_OK"));
+      batch.add(makeMessage("2.5", "CTRL_BAD"));
+      batch.end();
+
+      await expect(outbound.sendMessage(batch)).rejects.toThrow(
+        'message version "2.5" does not match the connection version "2.7".',
+      );
+
+      client.closeAll();
+    });
+
+    test("rejects a file batch when a contained message mismatches the version", async () => {
+      const client = new Client({ host: "localhost", version: "2.7" });
+      const outbound = client.createConnection(
+        { autoConnect: false, port: 9999 },
+        async () => {},
+      );
+      vi.spyOn(outbound as any, "_connect").mockReturnValue();
+
+      const file = new FileBatch();
+      file.start();
+      file.add(makeMessage("2.7", "CTRL_OK"));
+      file.add(makeMessage("2.5", "CTRL_BAD"));
+      file.end();
+
+      await expect(outbound.sendMessage(file)).rejects.toThrow(
+        'message version "2.5" does not match the connection version "2.7".',
+      );
+
+      client.closeAll();
+    });
+  });
+});

--- a/__tests__/server/hl7.end2end.test.ts
+++ b/__tests__/server/hl7.end2end.test.ts
@@ -54,17 +54,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("AA");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AA");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -95,17 +98,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("AR");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("AR");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AR");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("AR");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -136,17 +142,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("AE");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("AE");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AE");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("AE");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -177,17 +186,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("CA");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("CA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("CA");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("CA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -218,17 +230,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("CR");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("CR");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("CR");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("CR");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -259,17 +274,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("CE");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("CE");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("CE");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("CE");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -300,15 +318,18 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.1");
-        await res.sendResponse("CA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.1" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.1");
+          await res.sendResponse("CA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.1" });
 
       const outbound = client.createConnection(
         { port },
@@ -357,6 +378,7 @@ describe("node hl7 end to end - client", () => {
             "9.3": "ACK",
           },
           port,
+          version: "2.7",
         },
         async (request, res) => {
           const messageRequest = request.getMessage();
@@ -381,7 +403,7 @@ describe("node hl7 end to end - client", () => {
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },
@@ -412,17 +434,20 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        await res.sendResponse("AA");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AA");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port, waitAck: false },
         async () => {
@@ -450,7 +475,11 @@ describe("node hl7 end to end - client", () => {
   describe("server/client failure checks", () => {
     test("...host does not exist, error out", async () => {
       const port = await portfinder.getPortPromise();
-      const client = new Client({ connectionTimeout: 1000, host: "127.0.0.1" });
+      const client = new Client({
+        connectionTimeout: 1000,
+        host: "127.0.0.1",
+        version: "2.7",
+      });
       const outbound = client.createConnection(
         { maxConnectionAttempts: 1, port },
         async () => {},
@@ -471,17 +500,20 @@ describe("node hl7 end to end - client", () => {
         const dfd = createDeferred<void>();
 
         const server = new Server({ bindAddress: "0.0.0.0" });
-        const inbound = server.createInbound({ port }, async (request, res) => {
-          const messageRequest = request.getMessage();
-          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-          await res.sendResponse("AA");
-          const messageRes = res.getAckMessage();
-          expect(messageRes?.get("MSA.1").toString()).toBe("AA");
-        });
+        const inbound = server.createInbound(
+          { port, version: "2.7" },
+          async (request, res) => {
+            const messageRequest = request.getMessage();
+            expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+            await res.sendResponse("AA");
+            const messageRes = res.getAckMessage();
+            expect(messageRes?.get("MSA.1").toString()).toBe("AA");
+          },
+        );
 
         await expectEvent(inbound, "listen");
 
-        const client = new Client({ host: "0.0.0.0" });
+        const client = new Client({ host: "0.0.0.0", version: "2.7" });
         const outbound = client.createConnection(
           { port },
           async (res: InboundResponse) => {
@@ -531,19 +563,23 @@ describe("node hl7 end to end - client", () => {
             rejectUnauthorized: false,
           },
         });
-        const inbound = server.createInbound({ port }, async (request, res) => {
-          const messageRequest = request.getMessage();
-          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-          await res.sendResponse("AA");
-          const messageRes = res.getAckMessage();
-          expect(messageRes?.get("MSA.1").toString()).toBe("AA");
-        });
+        const inbound = server.createInbound(
+          { port, version: "2.7" },
+          async (request, res) => {
+            const messageRequest = request.getMessage();
+            expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+            await res.sendResponse("AA");
+            const messageRes = res.getAckMessage();
+            expect(messageRes?.get("MSA.1").toString()).toBe("AA");
+          },
+        );
 
         await expectEvent(inbound, "listen");
 
         const client = new Client({
           host: "0.0.0.0",
           tls: { rejectUnauthorized: false },
+          version: "2.7",
         });
         const outbound = client.createConnection(
           { port },
@@ -574,18 +610,21 @@ describe("node hl7 end to end - client", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const messageRequest = request.getMessage();
-        expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
-        expect(messageRequest.get("OBX.3.1").toString()).toBe("SOME-PDF");
-        await res.sendResponse("AA");
-        const messageRes = res.getAckMessage();
-        expect(messageRes?.get("MSA.1").toString()).toBe("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const messageRequest = request.getMessage();
+          expect(messageRequest.get("MSH.12").toString()).toBe("2.7");
+          expect(messageRequest.get("OBX.3.1").toString()).toBe("SOME-PDF");
+          await res.sendResponse("AA");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
 
       const outbound = client.createConnection(
         { port },

--- a/__tests__/server/hl7.issues.test.ts
+++ b/__tests__/server/hl7.issues.test.ts
@@ -72,21 +72,24 @@ describe("node hl7 server - issue coverage", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const socket = request.getSocket();
-        // The exact concrete class is net.Socket (or tls.TLSSocket which extends it).
-        expect(socket).toBeInstanceOf(net.Socket);
-        // localPort should match the port we bound to.
-        expect(socket.localPort).toBe(port);
-        // Both ends of the connection should have addresses available.
-        expect(typeof socket.remoteAddress).toBe("string");
-        expect(typeof socket.localAddress).toBe("string");
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const socket = request.getSocket();
+          // The exact concrete class is net.Socket (or tls.TLSSocket which extends it).
+          expect(socket).toBeInstanceOf(net.Socket);
+          // localPort should match the port we bound to.
+          expect(socket.localPort).toBe(port);
+          // Both ends of the connection should have addresses available.
+          expect(typeof socket.remoteAddress).toBe("string");
+          expect(typeof socket.localAddress).toBe("string");
+          await res.sendResponse("AA");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port },
         async (_res: InboundResponse) => {
@@ -110,31 +113,36 @@ describe("node hl7 server - issue coverage", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const original = request.getMessage();
-        // Build a vendor-shaped ACK that does NOT come from the auto-generator.
-        // Note the additional MSA fields (MSA.3 text + custom MSA.6) and the
-        // explicit ERR segment that sendResponse() would never produce.
-        const customAck = new Message({
-          text: [
-            String.raw`MSH|^~\&|CUSTOM_APP|CUSTOM_FAC|REMOTE_APP|REMOTE_FAC|${createHL7Date(new Date())}||ACK^A01|RESP_${original.get("MSH.10").toString()}|P|2.5`,
-            `MSA|AA|${original.get("MSH.10").toString()}|Custom message accepted|||VENDOR_CODE`,
-            `ERR|||0^Message accepted^HL70357|I`,
-          ].join("\r"),
-        });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const original = request.getMessage();
+          // Build a vendor-shaped ACK that does NOT come from the auto-generator.
+          // Note the additional MSA fields (MSA.3 text + custom MSA.6) and the
+          // explicit ERR segment that sendResponse() would never produce.
+          const customAck = new Message({
+            text: [
+              String.raw`MSH|^~\&|CUSTOM_APP|CUSTOM_FAC|REMOTE_APP|REMOTE_FAC|${createHL7Date(new Date())}||ACK^A01|RESP_${original.get("MSH.10").toString()}|P|2.5`,
+              `MSA|AA|${original.get("MSH.10").toString()}|Custom message accepted|||VENDOR_CODE`,
+              `ERR|||0^Message accepted^HL70357|I`,
+            ].join("\r"),
+          });
 
-        await res.sendCustomResponse(customAck);
+          await res.sendCustomResponse(customAck);
 
-        // After sending, getAckMessage() should reflect the custom ACK.
-        const stored = res.getAckMessage();
-        expect(stored?.get("MSH.3").toString()).toBe("CUSTOM_APP");
-        expect(stored?.get("MSA.3").toString()).toBe("Custom message accepted");
-        expect(stored?.get("MSA.6").toString()).toBe("VENDOR_CODE");
-      });
+          // After sending, getAckMessage() should reflect the custom ACK.
+          const stored = res.getAckMessage();
+          expect(stored?.get("MSH.3").toString()).toBe("CUSTOM_APP");
+          expect(stored?.get("MSA.3").toString()).toBe(
+            "Custom message accepted",
+          );
+          expect(stored?.get("MSA.6").toString()).toBe("VENDOR_CODE");
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port },
         async (res: InboundResponse) => {
@@ -163,19 +171,22 @@ describe("node hl7 server - issue coverage", () => {
       const dfd = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const original = request.getMessage();
-        const raw = [
-          String.raw`MSH|^~\&|RAW|FAC|R|RF|${createHL7Date(new Date())}||ACK^A01|RAW_${original.get("MSH.10").toString()}|P|2.5`,
-          `MSA|AA|${original.get("MSH.10").toString()}`,
-        ].join("\r");
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const original = request.getMessage();
+          const raw = [
+            String.raw`MSH|^~\&|RAW|FAC|R|RF|${createHL7Date(new Date())}||ACK^A01|RAW_${original.get("MSH.10").toString()}|P|2.5`,
+            `MSA|AA|${original.get("MSH.10").toString()}`,
+          ].join("\r");
 
-        await res.sendCustomResponse(raw);
-      });
+          await res.sendCustomResponse(raw);
+        },
+      );
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port },
         async (res: InboundResponse) => {
@@ -201,21 +212,24 @@ describe("node hl7 server - issue coverage", () => {
       const ackReceived = createDeferred<void>();
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const ack = new Message({
-          text: [
-            String.raw`MSH|^~\&|A|F|R|RF|${createHL7Date(new Date())}||ACK|X${request.getMessage().get("MSH.10").toString()}|P|2.5`,
-            `MSA|AA|${request.getMessage().get("MSH.10").toString()}`,
-          ].join("\r"),
-        });
-        await res.sendCustomResponse(ack);
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const ack = new Message({
+            text: [
+              String.raw`MSH|^~\&|A|F|R|RF|${createHL7Date(new Date())}||ACK|X${request.getMessage().get("MSH.10").toString()}|P|2.5`,
+              `MSA|AA|${request.getMessage().get("MSH.10").toString()}`,
+            ].join("\r"),
+          });
+          await res.sendCustomResponse(ack);
+        },
+      );
 
       listener.on("response.sent", () => responseSent.resolve());
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port },
         async (_res: InboundResponse) => {
@@ -247,18 +261,21 @@ describe("node hl7 server - issue coverage", () => {
       const dataErrors: any[] = [];
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const id = request.getMessage().get("MSH.10").toString();
-        seenControlIds.add(id);
-        await res.sendResponse("AA");
-        if (seenControlIds.size === expected) allDone.resolve();
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const id = request.getMessage().get("MSH.10").toString();
+          seenControlIds.add(id);
+          await res.sendResponse("AA");
+          if (seenControlIds.size === expected) allDone.resolve();
+        },
+      );
       listener.on("data.error", (error) => dataErrors.push(error));
 
       await expectEvent(listener, "listen");
 
-      const clientA = new Client({ host: "0.0.0.0" });
-      const clientB = new Client({ host: "0.0.0.0" });
+      const clientA = new Client({ host: "0.0.0.0", version: "2.7" });
+      const clientB = new Client({ host: "0.0.0.0", version: "2.7" });
       const outboundA = clientA.createConnection(
         { port, waitAck: false },
         async () => {},
@@ -306,9 +323,12 @@ describe("node hl7 server - issue coverage", () => {
       const dataErrors: any[] = [];
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        await res.sendResponse("AA");
-      });
+      const listener = server.createInbound(
+        { port, version: "2.5" },
+        async (request, res) => {
+          await res.sendResponse("AA");
+        },
+      );
       listener.on("data.error", (error) => dataErrors.push(error));
 
       await expectEvent(listener, "listen");
@@ -372,17 +392,20 @@ describe("node hl7 server - issue coverage", () => {
       const dataErrors: any[] = [];
 
       const server = new Server({ bindAddress: "0.0.0.0" });
-      const listener = server.createInbound({ port }, async (request, res) => {
-        const id = request.getMessage().get("MSH.10").toString();
-        seen.add(id);
-        await res.sendResponse("AA");
-        if (seen.size === total) allDone.resolve();
-      });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          const id = request.getMessage().get("MSH.10").toString();
+          seen.add(id);
+          await res.sendResponse("AA");
+          if (seen.size === total) allDone.resolve();
+        },
+      );
       listener.on("data.error", (error) => dataErrors.push(error));
 
       await expectEvent(listener, "listen");
 
-      const client = new Client({ host: "0.0.0.0" });
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
       const outbound = client.createConnection(
         { port, waitAck: false },
         async () => {},

--- a/__tests__/server/hl7.server.test.ts
+++ b/__tests__/server/hl7.server.test.ts
@@ -142,7 +142,7 @@ describe("node hl7 server", () => {
       try {
         const server = new Server();
         // @ts-expect-error port is not specified
-        server.createInbound();
+        server.createInbound({ version: "2.7" });
       } catch (error: any) {
         expect(error.message).toBe("port is not defined.");
       }
@@ -152,7 +152,7 @@ describe("node hl7 server", () => {
       try {
         const server = new Server();
         // @ts-expect-error port is not a number
-        server.createInbound({ port: "12345" }, async () => {});
+        server.createInbound({ port: "12345", version: "2.7" }, async () => {});
       } catch (error: any) {
         expect(error.message).toBe("port is not a valid number.");
       }
@@ -161,7 +161,7 @@ describe("node hl7 server", () => {
     test("rejects negative port", async () => {
       try {
         const server = new Server();
-        server.createInbound({ port: -1 }, async () => {});
+        server.createInbound({ port: -1, version: "2.7" }, async () => {});
       } catch (error: any) {
         expect(error.message).toEqual("port must be a number (0, 65353).");
       }
@@ -170,7 +170,7 @@ describe("node hl7 server", () => {
     test("rejects port above 65353", async () => {
       try {
         const server = new Server();
-        server.createInbound({ port: 65_354 }, async () => {});
+        server.createInbound({ port: 65_354, version: "2.7" }, async () => {});
       } catch (error: any) {
         expect(error.message).toBe("port must be a number (0, 65353).");
       }

--- a/__tests__/server/hl7.version.test.ts
+++ b/__tests__/server/hl7.version.test.ts
@@ -1,0 +1,155 @@
+/*
+MIT License
+
+Copyright (c) 2026 Shane
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+import Client, { InboundResponse, Message } from "node-hl7-client/src";
+import Server, { HL7ListenerError } from "node-hl7-server/src";
+import portfinder from "portfinder";
+import { describe, expect, test } from "vitest";
+
+import { createDeferred, expectEvent } from "./__utils__";
+
+/** Build a valid HL7 message at a specific version. */
+function makeMessage(
+  version: string,
+  controlId: string = "CONTROL_ID",
+): Message {
+  return new Message({
+    text: String.raw`MSH|^~\&|||||20240101000000||ADT^A01|${controlId}|D|${version}`,
+  });
+}
+
+describe("server HL7 version pin", () => {
+  describe("createInbound construction", () => {
+    test("throws when version is missing", () => {
+      expect.assertions(2);
+      const server = new Server({ bindAddress: "0.0.0.0" });
+      try {
+        // @ts-expect-error version is required
+        server.createInbound({ port: 3000 }, async () => {});
+      } catch (error) {
+        expect(error).toBeInstanceOf(HL7ListenerError);
+        expect((error as HL7ListenerError).message).toBe(
+          "version is not defined.",
+        );
+      }
+    });
+
+    test("throws when version is not a known HL7 version", () => {
+      expect.assertions(2);
+      const server = new Server({ bindAddress: "0.0.0.0" });
+      try {
+        // @ts-expect-error version must be a known HL7 version
+        server.createInbound({ port: 3000, version: "2.9" }, async () => {});
+      } catch (error) {
+        expect(error).toBeInstanceOf(HL7ListenerError);
+        expect((error as HL7ListenerError).message).toBe(
+          'version "2.9" is not a known HL7 version.',
+        );
+      }
+    });
+  });
+
+  describe("inbound enforcement", () => {
+    test("matched round-trip reaches the handler and is ACKed", async () => {
+      const port = await portfinder.getPortPromise();
+      const dfd = createDeferred<void>();
+      let handlerCalled = false;
+
+      const server = new Server({ bindAddress: "0.0.0.0" });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          handlerCalled = true;
+          expect(request.getMessage().get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AA");
+        },
+      );
+
+      await expectEvent(listener, "listen");
+
+      const client = new Client({ host: "0.0.0.0", version: "2.7" });
+      const outbound = client.createConnection(
+        { port },
+        async (res: InboundResponse) => {
+          expect(res.getMessage().get("MSA.1").toString()).toBe("AA");
+          dfd.resolve();
+        },
+      );
+
+      await expectEvent(outbound, "connect");
+      await outbound.sendMessage(makeMessage("2.7"));
+      await dfd.promise;
+
+      expect(handlerCalled).toBe(true);
+
+      await outbound.close();
+      await listener.close();
+      client.closeAll();
+    });
+
+    test("mismatched inbound is AR-rejected, emits the error event, and skips the handler", async () => {
+      const port = await portfinder.getPortPromise();
+      const ackReceived = createDeferred<void>();
+      const errorReceived = createDeferred<HL7ListenerError>();
+      let handlerCalled = false;
+
+      // listener pins 2.7; client sends 2.5
+      const server = new Server({ bindAddress: "0.0.0.0" });
+      const listener = server.createInbound(
+        { port, version: "2.7" },
+        async (request, res) => {
+          handlerCalled = true;
+          await res.sendResponse("AA");
+        },
+      );
+      listener.on("data.error", (error) => errorReceived.resolve(error));
+
+      await expectEvent(listener, "listen");
+
+      const client = new Client({ host: "0.0.0.0", version: "2.5" });
+      const outbound = client.createConnection(
+        { port },
+        async (res: InboundResponse) => {
+          expect(res.getMessage().get("MSA.1").toString()).toBe("AR");
+          ackReceived.resolve();
+        },
+      );
+
+      await expectEvent(outbound, "connect");
+      await outbound.sendMessage(makeMessage("2.5"));
+
+      await ackReceived.promise;
+      const error = await errorReceived.promise;
+
+      expect(error).toBeInstanceOf(HL7ListenerError);
+      expect(error.message).toBe(
+        'message version "2.5" does not match the listener version "2.7".',
+      );
+      // the handler must not have run for a rejected message
+      expect(handlerCalled).toBe(false);
+
+      await outbound.close();
+      await listener.close();
+      client.closeAll();
+    });
+  });
+});

--- a/docker/server.js
+++ b/docker/server.js
@@ -50,7 +50,7 @@ const log = (level, message, extra = {}) => {
 const server = new Server({ bindAddress: BIND });
 
 const inbound = server.createInbound(
-  { name: "HL7_LISTENER", port: PORT },
+  { name: "HL7_LISTENER", port: PORT, version: "2.7" },
   async (request, res) => {
     const message = request.getMessage();
     log("info", "received", {

--- a/docker/smoke.mjs
+++ b/docker/smoke.mjs
@@ -47,7 +47,7 @@ const overallTimer = setTimeout(
   OVERALL_TIMEOUT_MS,
 );
 
-const client = new Client({ host: HOST });
+const client = new Client({ host: HOST, version: "2.7" });
 
 let ackReceived = false;
 const ackPromise = new Promise((resolve, reject) => {

--- a/docker/smoke.tls.mjs
+++ b/docker/smoke.tls.mjs
@@ -60,6 +60,7 @@ const client = new Client({
     rejectUnauthorized: true,
     servername: "localhost",
   },
+  version: "2.7",
 });
 
 let ackReceived = false;

--- a/docker/tls.server.js
+++ b/docker/tls.server.js
@@ -81,7 +81,7 @@ if (tlsCaPath) {
 const server = new Server({ bindAddress: BIND, tls });
 
 const inbound = server.createInbound(
-  { name: "HL7_LISTENER_TLS", port: PORT },
+  { name: "HL7_LISTENER_TLS", port: PORT, version: "2.7" },
   async (request, res) => {
     const message = request.getMessage();
     const sock = request.getSocket();

--- a/packages/node-hl7-client/README.md
+++ b/packages/node-hl7-client/README.md
@@ -57,9 +57,10 @@ const message = new HL7_2_5()
     msh_4: "MY_FAC",
     msh_5: "EPIC",
     msh_6: "HOSP",
-    msh_9: "ADT^A01",
+    msh_9_1: "ADT",
+    msh_9_2: "A01",
     msh_10: "MSG00001",
-    msh_11: "P",
+    msh_11_1: "P",
   })
   .buildEVN({ evn_1: "A01" })
   .buildPID({
@@ -70,8 +71,9 @@ const message = new HL7_2_5()
   })
   .toMessage();
 
-// 2) Open a persistent connection and send it.
-const client = new Client({ host: "127.0.0.1" });
+// 2) Open a persistent connection and send it. The client version is required
+// and must match the MSH.12 of every message you send through it.
+const client = new Client({ host: "127.0.0.1", version: "2.5" });
 const conn = client.createConnection({ port: 3000 }, async (res) => {
   console.log("✅ ACK:", res.getMessage().get("MSA.1").toString()); // AA
 });
@@ -262,6 +264,7 @@ import Client from "node-hl7-client";
 
 const client = new Client({
   host: "127.0.0.1",
+  version: "2.7",
 });
 
 const OB_ADT = client.createConnection(
@@ -288,22 +291,28 @@ The client supports IPv4, IPv6, and FQDN hosts. **It runs IPv4-only by default.*
 
 ```ts
 // IPv4 only (default)
-const client = new Client({ host: "hl7.example.com" });
+const client = new Client({ host: "hl7.example.com", version: "2.7" });
 
 // Dual-stack with auto-fallback (opt-in)
-const dual = new Client({ host: "hl7.example.com", ipv4: true, ipv6: true });
+const dual = new Client({
+  host: "hl7.example.com",
+  ipv4: true,
+  ipv6: true,
+  version: "2.7",
+});
 
 // Force IPv6 only
-const v6Only = new Client({ host: "fd00::42", ipv6: true });
+const v6Only = new Client({ host: "fd00::42", ipv6: true, version: "2.7" });
 
 // Pin a specific termination address (when the host has multiple)
-const pinned = new Client({ host: "fe80::1234", ipv6: true });
+const pinned = new Client({ host: "fe80::1234", ipv6: true, version: "2.7" });
 
 // Tune Happy-Eyeballs cadence (defaults shown — only takes effect in dual-stack):
 const tuned = new Client({
   host: "hl7.example.com",
   ipv4: true,
   ipv6: true,
+  version: "2.7",
   autoSelectFamily: true,             // default
   autoSelectFamilyAttemptTimeout: 250, // ms before racing the other family
 });
@@ -331,6 +340,7 @@ import Client from "node-hl7-client";
 
 const client = new Client({
   host: "hl7.example.local",
+  version: "2.7",
   tls: {
     // ✅ Validate the server's certificate (production default).
     rejectUnauthorized: true,
@@ -351,7 +361,7 @@ await OB_ADT.sendMessage(message);
 The shorthand `tls: true` is also accepted when the server uses a cert chained to a public CA already in Node's trust store:
 
 ```ts
-const client = new Client({ host: "hl7.example.com", tls: true });
+const client = new Client({ host: "hl7.example.com", tls: true, version: "2.7" });
 ```
 
 ---
@@ -367,6 +377,7 @@ import Client from "node-hl7-client";
 
 const client = new Client({
   host: "hl7.example.local",
+  version: "2.7",
   tls: {
     // 🔑 The client's identity — what the remote server validates.
     key: fs.readFileSync(path.join("certs", "client-key.pem")),
@@ -451,7 +462,7 @@ const flushQueue = async (
   }
 };
 
-const client = new Client({ host: "127.0.0.1" });
+const client = new Client({ host: "127.0.0.1", version: "2.7" });
 const conn = client.createConnection(
   { port: 3000, autoConnect: false, enqueueMessage, flushQueue },
   async () => {},

--- a/packages/node-hl7-client/src/client/connection.ts
+++ b/packages/node-hl7-client/src/client/connection.ts
@@ -291,6 +291,29 @@ export class Connection extends EventEmitter implements IConnection {
    */
   async sendMessage(message: Batch | FileBatch | Message): Promise<void> {
     const theMessage = message.toString();
+
+    // Enforce the client-pinned HL7 version before the message is queued or
+    // sent. A Batch/FileBatch must have every contained message match. Parsing
+    // the serialized form lets `messages()` enumerate the contained MSH
+    // segments regardless of whether the batch was built or received as text.
+    const want = this._main._opt.version;
+    let messagesToCheck: Message[];
+    if (message instanceof FileBatch) {
+      messagesToCheck = new FileBatch({ text: theMessage }).messages();
+    } else if (message instanceof Batch) {
+      messagesToCheck = new Batch({ text: theMessage }).messages();
+    } else {
+      messagesToCheck = [message];
+    }
+    for (const msg of messagesToCheck) {
+      const got = msg.get("MSH.12").toString();
+      if (got !== want) {
+        throw new HL7FatalError(
+          `message version "${got}" does not match the connection version "${want}".`,
+        );
+      }
+    }
+
     const emitter = new EventEmitter();
     const codec = new MLLPCodec(this._opt.encoding);
     const maxAttempts = this._opt.maxAttempts;

--- a/packages/node-hl7-client/src/client/normalizedClient.ts
+++ b/packages/node-hl7-client/src/client/normalizedClient.ts
@@ -25,6 +25,7 @@ import type { ConnectionOptions as TLSOptions } from "node:tls";
 import { TcpSocketConnectOpts } from "node:net";
 
 import { HL7FatalError } from "@/helpers/exception";
+import { HL7Version, isKnownVersion } from "@/hl7/metadata/types";
 import { ClientListenerOptions, ClientOptions } from "@/modules/types";
 import { assertNumber } from "@/utils";
 import { detectIPFamily, validIPv4, validIPv6 } from "@/utils/ipAddress";
@@ -94,6 +95,7 @@ interface ValidatedClientOptions extends Pick<
   retryLow: number;
   socket?: TcpSocketConnectOpts;
   tls?: TLSOptions;
+  version: HL7Version;
 }
 
 /** @internal */
@@ -167,6 +169,16 @@ export function normalizeClientOptions(
 
   if (typeof properties.host !== "string") {
     throw new HL7FatalError("host is not valid string.");
+  }
+
+  if (properties.version === undefined) {
+    throw new HL7FatalError("version is not defined.");
+  }
+
+  if (!isKnownVersion(properties.version)) {
+    throw new HL7FatalError(
+      `version "${properties.version}" is not a known HL7 version.`,
+    );
   }
 
   if (properties.ipv4 === false && properties.ipv6 === false) {

--- a/packages/node-hl7-client/src/hl7.ts
+++ b/packages/node-hl7-client/src/hl7.ts
@@ -152,6 +152,7 @@ export {
 } from "@/hl7/metadata/datatypes";
 export { SEGMENT_SPECS } from "@/hl7/metadata/segments";
 export { ECD_SPEC } from "@/hl7/metadata/segments/ecd";
+export { isKnownVersion, KNOWN_VERSIONS } from "@/hl7/metadata/types";
 export type {
   ComponentSpec,
   FieldSpec,

--- a/packages/node-hl7-client/src/hl7/metadata/types.ts
+++ b/packages/node-hl7-client/src/hl7/metadata/types.ts
@@ -131,6 +131,25 @@ export type HL7Version =
   | "2.8";
 
 /**
+ * Runtime list of the HL7 v2 spec versions recognized by this library, in
+ * ascending order. Used to validate a client/listener `version` at runtime.
+ * @since 4.0.0
+ */
+export const KNOWN_VERSIONS: readonly HL7Version[] = [
+  "2.1",
+  "2.2",
+  "2.3",
+  "2.3.1",
+  "2.4",
+  "2.5",
+  "2.5.1",
+  "2.6",
+  "2.7",
+  "2.7.1",
+  "2.8",
+];
+
+/**
  * Description of an HL7 segment, with per-version availability and field set.
  * @since 4.0.0
  */
@@ -146,4 +165,15 @@ export interface SegmentSpec {
    * not in this list must reject calls to build the segment.
    */
   versions: readonly HL7Version[];
+}
+
+/**
+ * Runtime guard for {@link HL7Version}. Returns `true` when `v` is one of the
+ * {@link KNOWN_VERSIONS}.
+ * @since 4.0.0
+ */
+export function isKnownVersion(v: unknown): v is HL7Version {
+  return (
+    typeof v === "string" && (KNOWN_VERSIONS as readonly string[]).includes(v)
+  );
 }

--- a/packages/node-hl7-client/src/modules/types.ts
+++ b/packages/node-hl7-client/src/modules/types.ts
@@ -26,6 +26,7 @@ import { TcpSocketConnectOpts } from "node:net";
 
 import { InboundResponse } from "@/client/inboundResponse";
 import { MSH } from "@/hl7/headers";
+import { HL7Version } from "@/hl7/metadata/types";
 
 import { Batch, FileBatch, Message } from "../builder";
 
@@ -241,6 +242,13 @@ export interface ClientOptions {
   /** Enable TLS, or set TLS specific options like overriding the CA for
    * self-signed certificates. */
   tls?: boolean | TLSOptions;
+  /** The HL7 version this client pins. Required. Every message (or every
+   * message contained in a batch/file) sent through a connection must carry a
+   * matching `MSH.12`, or the send is rejected before it is queued.
+   * Must be one of the known HL7 versions
+   * (2.1, 2.2, 2.3, 2.3.1, 2.4, 2.5, 2.5.1, 2.6, 2.7, 2.7.1, 2.8).
+   * @since 4.0.0 */
+  version: HL7Version;
 }
 
 export type FallBackHandler = (message: MessageItem) => void;

--- a/packages/node-hl7-server/README.md
+++ b/packages/node-hl7-server/README.md
@@ -58,13 +58,18 @@ import { Server } from "node-hl7-server";
 
 const server = new Server({ bindAddress: "0.0.0.0" });
 
-const IB_ADT = server.createInbound({ port: 3000 }, async (req, res) => {
-  const message = req.getMessage();
-  console.log("⬅️  received", message.get("MSH.10").toString());
+// The listener version is required. Any inbound whose MSH.12 differs is
+// rejected with an "AR" and the handler never runs.
+const IB_ADT = server.createInbound(
+  { port: 3000, version: "2.7" },
+  async (req, res) => {
+    const message = req.getMessage();
+    console.log("⬅️  received", message.get("MSH.10").toString());
 
-  // Tell the sender we accepted it.
-  await res.sendResponse("AA");
-});
+    // Tell the sender we accepted it.
+    await res.sendResponse("AA");
+  },
+);
 
 IB_ADT.on("listen", () => console.log("🎧 listening on :3000"));
 ```
@@ -159,6 +164,10 @@ server.createInbound(props: ListenerOptions, handler: InboundHandler): Inbound;
 interface ListenerOptions {
   /** Required. 0 < port < 65353. */
   port: number;
+  /** Required. The HL7 version this listener pins (2.1, 2.2, 2.3, 2.3.1, 2.4,
+   *  2.5, 2.5.1, 2.6, 2.7, 2.7.1, 2.8). Inbound messages whose MSH.12 differs
+   *  are rejected with an "AR" and the handler is not invoked. */
+  version: HL7Version;
   /** Optional human‑readable name for logging. */
   name?: string;
   /** Encoding for inbound bytes. Default: utf-8 */
@@ -179,7 +188,7 @@ The handler gets called **once per parsed message**, even when the inbound frame
 ## 📨 Reading the Request
 
 ```ts
-server.createInbound({ port: 3000 }, async (req, res) => {
+server.createInbound({ port: 3000, version: "2.7" }, async (req, res) => {
   const msg = req.getMessage();           // Message from node-hl7-client
   const type = req.getType();             // 'message' | 'batch' | 'file'
   const sock = req.getSocket();           // 🔌 the underlying net.Socket
@@ -233,7 +242,7 @@ When the receiving system expects a vendor‑shaped acknowledgement (extra `MSA`
 ```ts
 import { Message, createHL7Date } from "node-hl7-client";
 
-server.createInbound({ port: 3000 }, async (req, res) => {
+server.createInbound({ port: 3000, version: "2.7" }, async (req, res) => {
   const original = req.getMessage();
   const ctrlId = original.get("MSH.10").toString();
 
@@ -263,6 +272,7 @@ import { format } from "date-fns";
 server.createInbound(
   {
     port: 3000,
+    version: "2.7",
     mshOverrides: {
       "3": "MY_APP",                                              // literal
       "7": () => format(new Date(), "yyyyMMddHHmmssxx"),          // callback
@@ -343,7 +353,7 @@ const server = new Server({
   },
 });
 
-const IB = server.createInbound({ port: 6661 }, async (req, res) => {
+const IB = server.createInbound({ port: 6661, version: "2.7" }, async (req, res) => {
   // The TLS handshake has already enforced the client cert.
   // You can still inspect peer details via the socket:
   const sock = req.getSocket() as import("tls").TLSSocket;

--- a/packages/node-hl7-server/src/server/inbound.ts
+++ b/packages/node-hl7-server/src/server/inbound.ts
@@ -33,6 +33,7 @@ import net, { Socket } from "node:net";
 import tls from "node:tls";
 
 import { BaseSendResponse } from "@/declaration/baseSendRequest";
+import { HL7ListenerError } from "@/utils/exception";
 import { ListenerOptions, normalizeListenerOptions } from "@/utils/normalize";
 
 import { InboundRequest } from "./inboundRequest";
@@ -174,6 +175,22 @@ export class Inbound extends EventEmitter implements IInbound {
       );
 
       res.on("response.sent", () => this.emit("response.sent"));
+
+      // Enforce the listener-pinned HL7 version. On a mismatch, reject the
+      // message with an "AR" acknowledgement, surface the error, and skip the
+      // user handler.
+      const got = parsed.get("MSH.12").toString();
+      if (got !== this._opt.version) {
+        void res.sendResponse("AR");
+        this.emit(
+          "data.error",
+          new HL7ListenerError(
+            `message version "${got}" does not match the listener version "${this._opt.version}".`,
+          ),
+        );
+        continue;
+      }
+
       void this._handler(request, res);
     }
   };
@@ -309,6 +326,22 @@ export class Inbound extends EventEmitter implements IInbound {
             );
 
             res.on("response.sent", () => this.emit("response.sent"));
+
+            // Enforce the listener-pinned HL7 version. On a mismatch, reject
+            // the message with an "AR" acknowledgement, surface the error, and
+            // skip the user handler.
+            const got = parsed.get("MSH.12").toString();
+            if (got !== this._opt.version) {
+              void res.sendResponse("AR");
+              this.emit(
+                "data.error",
+                new HL7ListenerError(
+                  `message version "${got}" does not match the listener version "${this._opt.version}".`,
+                ),
+              );
+              return;
+            }
+
             void this._handler(request, res);
           }
         } catch (error) {

--- a/packages/node-hl7-server/src/utils/normalize.ts
+++ b/packages/node-hl7-server/src/utils/normalize.ts
@@ -24,6 +24,8 @@ import type { ConnectionOptions as TLSOptions } from "node:tls";
 
 import {
   assertNumber,
+  HL7Version,
+  isKnownVersion,
   Message,
   randomString,
   validIPv4,
@@ -66,6 +68,12 @@ export interface ListenerOptions {
    * you need to extend the base BaseSendResponse class from
    *  **/
   responseClass?: typeof BaseSendResponse;
+  /** The HL7 version this listener pins. Required. Any inbound message whose
+   * `MSH.12` does not match is rejected with an `AR` acknowledgement and the
+   * handler is not invoked. Must be one of the known HL7 versions
+   * (2.1, 2.2, 2.3, 2.3.1, 2.4, 2.5, 2.5.1, 2.6, 2.7, 2.7.1, 2.8).
+   * @since 4.0.0 */
+  version: HL7Version;
 }
 
 /**
@@ -142,6 +150,7 @@ interface ValidatedOptions extends Pick<
   name?: string;
   port: number;
   responseClass?: typeof BaseSendResponse;
+  version: HL7Version;
 }
 
 /** @internal */
@@ -173,6 +182,16 @@ export function normalizeListenerOptions(
         );
       }
     }
+  }
+
+  if (merged.version === undefined) {
+    throw new HL7ListenerError("version is not defined.");
+  }
+
+  if (!isKnownVersion(merged.version)) {
+    throw new HL7ListenerError(
+      `version "${merged.version}" is not a known HL7 version.`,
+    );
   }
 
   if (merged.port === undefined) {


### PR DESCRIPTION
Implements #19. Adds a required, enforced HL7 `version` to the client and to each inbound listener (mirrors go-hl7).

- Client: `ClientOptions.version` required; `sendMessage` rejects any message (and every message in a batch/file) whose MSH.12 differs from the client version.
- Server: `createInbound` requires `version`; a mismatched inbound gets an `AR` reply, emits the data.error event, and skips the handler. ACK still echoes the inbound version.
- All `new Client`/`createInbound` call sites (tests + docker) version-aligned; READMEs + AGENTS.md updated; builder README example fixed to composite keys.

Build OK; test 575 passed / 2 skipped; lint clean; golic 0 changed.

Closes #19