### PR TITLE
ci: idempotent npm publish with propagation pause and server retry

### DIFF
--- a/.github/workflows/action-deploy-npm.yaml
+++ b/.github/workflows/action-deploy-npm.yaml
@@ -68,10 +68,39 @@ jobs:
       # No `--token` / NODE_AUTH_TOKEN — npm authenticates to the registry via
       # the OIDC token issued by GitHub Actions, matched against the trusted
       # publisher configured on npmjs.com.
+      # Each publish is idempotent: if that exact version is already on the
+      # registry (e.g. a partial-publish retry), skip it instead of failing.
       - name: Publish node-hl7-client
         working-directory: packages/node-hl7-client
-        run: npm publish --provenance --access public --ignore-scripts
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "node-hl7-client@${VERSION}" version >/dev/null 2>&1; then
+            echo "node-hl7-client@${VERSION} already published — skipping."
+          else
+            npm publish --provenance --access public --ignore-scripts
+          fi
+
+      # node-hl7-server peer-depends on node-hl7-client (^4.0.0). Give the
+      # registry a moment to make the just-published client resolvable before
+      # publishing the server.
+      - name: Pause for registry propagation
+        run: sleep 45
 
       - name: Publish node-hl7-server
         working-directory: packages/node-hl7-server
-        run: npm publish --provenance --access public --ignore-scripts
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "node-hl7-server@${VERSION}" version >/dev/null 2>&1; then
+            echo "node-hl7-server@${VERSION} already published — skipping."
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if npm publish --provenance --access public --ignore-scripts; then
+              echo "published on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; waiting 30s before retry..."
+            sleep 30
+          done
+          echo "node-hl7-server publish failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
The first v4.0.0 publish landed `node-hl7-client` but the `node-hl7-server` PUT returned a transient 404. Harden the publish job so a re-run recovers cleanly:

- **Idempotent** — skip a package whose exact version is already on the registry, so re-running doesn't fail on the already-published client.
- **Propagation pause** between client and server publishes (server peer-depends on client `^4.0.0`).
- **Retry** the server publish up to 3 times.