### PR TITLE
ci: dedicated dispatch-only publish workflow for node-hl7-server

### DIFF
--- a/.github/workflows/action-deploy-npm-server.yaml
+++ b/.github/workflows/action-deploy-npm-server.yaml
@@ -1,0 +1,86 @@
+# MIT License
+#
+# Copyright (c) 2026 Shane
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+name: Publish node-hl7-server
+# Dedicated publish workflow for node-hl7-server so its npm trusted-publisher
+# entry can point at this file by name (workflow-scoped OIDC identity), separate
+# from the client. Dispatch-only — the release-triggered action-deploy-npm.yaml
+# still handles the regular release flow, so this won't double-publish.
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+  actions: write
+  checks: write
+  id-token: write
+
+jobs:
+  Test:
+    uses: ./.github/workflows/action-test.yaml
+
+  Publish:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    runs-on: ubuntu-latest
+    needs: ['Test']
+    # id-token: write (declared at workflow scope) is what lets npm verify
+    # the OIDC token issued by GitHub against the trusted-publisher config
+    # registered on npmjs.com for node-hl7-server. That entry's "Workflow
+    # filename" must be action-deploy-npm-server.yaml for the claim to match.
+    steps:
+      - name: Download the build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: cache
+          path: ./
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org/'
+
+      # OIDC trusted publishing requires npm >= 11.5.1 (the Node 22 LTS image
+      # ships with npm 10.x). Provenance and trusted-publisher auth both
+      # depend on this client.
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - name: Publish node-hl7-server
+        working-directory: packages/node-hl7-server
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "node-hl7-server@${VERSION}" version >/dev/null 2>&1; then
+            echo "node-hl7-server@${VERSION} already published — skipping."
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if npm publish --provenance --access public --ignore-scripts; then
+              echo "published on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; waiting 30s before retry..."
+            sleep 30
+          done
+          echo "node-hl7-server publish failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
Gives node-hl7-server its own workflow file so its npm trusted-publisher entry can be scoped to a dedicated filename, separate from the client. Dispatch-only, so it does not double-publish alongside the release-triggered `action-deploy-npm.yaml`. Same idempotent publish-with-retry.