### PR TITLE
ci: finish per-package publish split, drop v4.0.0 seed

### DIFF
--- a/.github/workflows/action-deploy-npm-server.yaml
+++ b/.github/workflows/action-deploy-npm-server.yaml
@@ -21,11 +21,14 @@
 name: Publish node-hl7-server
 # Dedicated publish workflow for node-hl7-server so its npm trusted-publisher
 # entry can point at this file by name (workflow-scoped OIDC identity), separate
-# from the client. Dispatch-only — the release-triggered action-deploy-npm.yaml
-# still handles the regular release flow, so this won't double-publish.
+# from the client (which publishes from action-deploy-npm.yaml). Each workflow
+# publishes exactly one package, so a release fires both with no overlap.
 on:
   workflow_dispatch:
   workflow_call:
+  release:
+    types:
+      - released
 
 permissions:
   contents: write
@@ -38,7 +41,7 @@ jobs:
     uses: ./.github/workflows/action-test.yaml
 
   Publish:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: ['Test']
     # id-token: write (declared at workflow scope) is what lets npm verify

--- a/.github/workflows/action-deploy-npm.yaml
+++ b/.github/workflows/action-deploy-npm.yaml
@@ -18,7 +18,7 @@
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-name: Release and Publish
+name: Publish node-hl7-client
 on:
   workflow_dispatch:
   workflow_call:
@@ -41,8 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['Test']
     # id-token: write (declared at workflow scope) is what lets npm verify
-    # the OIDC token issued by GitHub against the trusted-publisher config
-    # registered on npmjs.com for each package.
+    # the OIDC token issued by GitHub against the node-hl7-client trusted
+    # publisher registered on npmjs.com. node-hl7-server publishes from its
+    # own workflow (action-deploy-npm-server.yaml).
     steps:
       - name: Download the build artifact
         uses: actions/download-artifact@v8
@@ -64,12 +65,11 @@ jobs:
           npm install -g npm@latest
           npm --version
 
-      # Publish client first because node-hl7-server peer-depends on it (^4.0.0).
       # No `--token` / NODE_AUTH_TOKEN — npm authenticates to the registry via
       # the OIDC token issued by GitHub Actions, matched against the trusted
       # publisher configured on npmjs.com.
-      # Each publish is idempotent: if that exact version is already on the
-      # registry (e.g. a partial-publish retry), skip it instead of failing.
+      # Idempotent: if that exact version is already on the registry (e.g. a
+      # partial-publish retry), skip it instead of failing.
       - name: Publish node-hl7-client
         working-directory: packages/node-hl7-client
         run: |
@@ -79,28 +79,3 @@ jobs:
           else
             npm publish --provenance --access public --ignore-scripts
           fi
-
-      # node-hl7-server peer-depends on node-hl7-client (^4.0.0). Give the
-      # registry a moment to make the just-published client resolvable before
-      # publishing the server.
-      - name: Pause for registry propagation
-        run: sleep 45
-
-      - name: Publish node-hl7-server
-        working-directory: packages/node-hl7-server
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if npm view "node-hl7-server@${VERSION}" version >/dev/null 2>&1; then
-            echo "node-hl7-server@${VERSION} already published — skipping."
-            exit 0
-          fi
-          for attempt in 1 2 3; do
-            if npm publish --provenance --access public --ignore-scripts; then
-              echo "published on attempt ${attempt}"
-              exit 0
-            fi
-            echo "attempt ${attempt} failed; waiting 30s before retry..."
-            sleep 30
-          done
-          echo "node-hl7-server publish failed after 3 attempts"
-          exit 1

--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -64,11 +64,6 @@ jobs:
       - name: 📝 Release Drafter (Anticipate Version)
         id: drafter
         uses: release-drafter/release-drafter@v6
-        with:
-          # One-time override to seed the first v4.0.0 release.
-          # REMOVE this `version:` line after v4.0.0 ships — subsequent
-          # versions resolve from PR labels via .github/release-drafter.yml.
-          version: '4.0.0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Completes the per-package publish split now that node-hl7-server has its own trusted-publisher entry and dedicated workflow.

- `action-deploy-npm.yaml` publishes **node-hl7-client only**.
- `action-deploy-npm-server.yaml` now triggers on **release** (not just dispatch) and publishes **node-hl7-server**. Each workflow publishes exactly one package, matching that package's npm trusted-publisher entry, so a release fires both with no overlap.
- Removes the one-time release-drafter `version: '4.0.0'` seed now that v4.0.0 has shipped; future versions resolve from PR labels.