### PR TITLE
chore: drop unlabeled ci/chore entries from v4.0.1 changelog

### DIFF
--- a/packages/node-hl7-client/CHANGELOG.md
+++ b/packages/node-hl7-client/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 ### What Changed 👀
 
-- chore(governance): sync shared governance from project-template @Bugs5382 (#25)
-- ci: finish per-package publish split, drop v4.0.0 seed @Bugs5382 (#24)
-- ci: dedicated dispatch-only publish workflow for node-hl7-server @Bugs5382 (#23)
-- ci: idempotent npm publish with propagation pause and server retry @Bugs5382 (#22)
-
 #### 🧩 Dependency Updates
 
 - chore(deps): bump the github-actions group with 9 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#27)

--- a/packages/node-hl7-server/CHANGELOG.md
+++ b/packages/node-hl7-server/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 ### What Changed 👀
 
-- chore(governance): sync shared governance from project-template @Bugs5382 (#25)
-- ci: finish per-package publish split, drop v4.0.0 seed @Bugs5382 (#24)
-- ci: dedicated dispatch-only publish workflow for node-hl7-server @Bugs5382 (#23)
-- ci: idempotent npm publish with propagation pause and server retry @Bugs5382 (#22)
-
 #### 🧩 Dependency Updates
 
 - chore(deps): bump the github-actions group with 9 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#27)


### PR DESCRIPTION
## What and why

PRs #22-25 (`ci:`/`chore:`) merged while autolabeling was broken (release-drafter v7 dropped `disable-releaser`), so they were never labeled `skip-changelog` and release-drafter listed them as uncategorized bullets under "What Changed" in the v4.0.1 changelog of both packages.

Those PRs are now relabeled `skip-changelog` and the v4.0.1 release draft is corrected. This removes the same four entries from both `CHANGELOG.md` files so v4.0.1 shows only the genuine Dependency Updates.

Closes #35

## Verification

- [x] Both CHANGELOG.md v4.0.1 sections now contain only the Dependency Updates
- [x] v4.0.1 release draft body corrected to match

## How this was verified

Diffed both changelogs (10 deletions); confirmed the release draft body shows only the dependency updates.